### PR TITLE
Fixes for MSVC compatibility:

### DIFF
--- a/src/tbconfig.h
+++ b/src/tbconfig.h
@@ -29,6 +29,28 @@
 /****************************************************************************/
 
 /*
+ * Define TB_CUSTOM_POP_COUNT to override the internal popcount
+ * implementation. To do this supply a macro or function with the signature:
+ * unsigned popcount(uint64_t x)
+ */
+/* #define TB_CUSTOM_POP_COUNT */
+
+/*
+ * Define TB_CUSTOM_LSB to override the internal lsb
+ * implementation. To do this supply a function or macro with the signature:
+ * unsigned lsb(uint64_t x)
+ */
+/* #define TB_CUSTOM_LSB */
+
+/*
+ * Define TB_CUSTOM_BSWAP to override the internal bswap*
+ * implementation. To do this supply macros or functions with the signatures:
+ * uint64_t bswap64(uint64_t x) and
+ * uint32_t bswap32(uint32_t x)
+ */
+/* #define TB_CUSTOM_BSWAP */
+
+/*
  * Define TB_NO_STDINT if you do not want to use <stdint.h> or it is not
  * available.
  */

--- a/src/tbconfig.h
+++ b/src/tbconfig.h
@@ -47,14 +47,14 @@
  * implementation. To do this supply a macro or function definition
  * here:
  */
-/* #define TB_CUSTOM_BSWAP32 <DEFINITION> */
+/* #define TB_CUSTOM_BSWAP32(x) <DEFINITION> */
 
 /*
  * Define TB_CUSTOM_BSWAP64 to override the internal bswap64
  * implementation. To do this supply a macro or function definition
  * here:
  */
-/* #define TB_CUSTOM_BSWAP64 <DEFINITION> */
+/* #define TB_CUSTOM_BSWAP64(x) <DEFINITION> */
 
 /*
  * Define TB_NO_STDINT if you do not want to use <stdint.h> or it is not

--- a/src/tbconfig.h
+++ b/src/tbconfig.h
@@ -30,25 +30,31 @@
 
 /*
  * Define TB_CUSTOM_POP_COUNT to override the internal popcount
- * implementation. To do this supply a macro or function with the signature:
- * unsigned popcount(uint64_t x)
+ * implementation. To do this supply a macro or function definition
+ * here:
  */
-/* #define TB_CUSTOM_POP_COUNT */
+/* #define TB_CUSTOM_POP_COUNT(x) <DEFINITION> */
 
 /*
  * Define TB_CUSTOM_LSB to override the internal lsb
- * implementation. To do this supply a function or macro with the signature:
- * unsigned lsb(uint64_t x)
+ * implementation. To do this supply a macro or function definition
+ * here:
  */
-/* #define TB_CUSTOM_LSB */
+/* #define TB_CUSTOM_LSB(x) <DEFINITION> */
 
 /*
- * Define TB_CUSTOM_BSWAP to override the internal bswap*
- * implementation. To do this supply macros or functions with the signatures:
- * uint64_t bswap64(uint64_t x) and
- * uint32_t bswap32(uint32_t x)
+ * Define TB_CUSTOM_BSWAP32 to override the internal bswap32
+ * implementation. To do this supply a macro or function definition
+ * here:
  */
-/* #define TB_CUSTOM_BSWAP */
+/* #define TB_CUSTOM_BSWAP32 <DEFINITION> */
+
+/*
+ * Define TB_CUSTOM_BSWAP64 to override the internal bswap64
+ * implementation. To do this supply a macro or function definition
+ * here:
+ */
+/* #define TB_CUSTOM_BSWAP64 <DEFINITION> */
 
 /*
  * Define TB_NO_STDINT if you do not want to use <stdint.h> or it is not

--- a/src/tbcore.c
+++ b/src/tbcore.c
@@ -8,16 +8,24 @@
 */
 
 #include <stdio.h>
-#include <unistd.h>
+#ifndef TB_NO_STDINT
 #include <stdint.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#ifndef __WIN32__
+#ifndef _WIN32
+#include <unistd.h>
 #include <sys/mman.h>
 #endif
 #include "tbcore.h"
+
+#if !defined(DECOMP64) && defined(_LP64)
+// use 64-bit decompression if OS is 64-bit
+// (appears not to work so commented out for now)
+//#define DECOMP64
+#endif
 
 #define TBMAX_PIECE 254
 #define TBMAX_PAWN 256
@@ -40,6 +48,11 @@
 
 #ifndef TB_NO_THREADS
 static LOCK_T TB_MUTEX;
+#endif
+
+#ifndef TB_CUSTOM_BSWAP
+#define bswap64(x) __builtin_bswap64(x)
+#define bswap32(x) __builtin_bswap32(x)
 #endif
 
 static int initialized = 0;
@@ -73,7 +86,7 @@ static FD open_tb(const char *str, const char *suffix)
     strcat(file, "/");
     strcat(file, str);
     strcat(file, suffix);
-#ifndef __WIN32__
+#ifndef _WIN32
     fd = open(file, O_RDONLY);
 #else
     fd = CreateFile(file, GENERIC_READ, FILE_SHARE_READ, NULL,
@@ -86,7 +99,7 @@ static FD open_tb(const char *str, const char *suffix)
 
 static void close_tb(FD fd)
 {
-#ifndef __WIN32__
+#ifndef _WIN32
   close(fd);
 #else
   CloseHandle(fd);
@@ -98,7 +111,7 @@ static char *map_file(const char *name, const char *suffix, uint64 *mapping)
   FD fd = open_tb(name, suffix);
   if (fd == FD_ERR)
     return NULL;
-#ifndef __WIN32__
+#ifndef _WIN32
   struct stat statbuf;
   fstat(fd, &statbuf);
   *mapping = statbuf.st_size;
@@ -129,7 +142,7 @@ static char *map_file(const char *name, const char *suffix, uint64 *mapping)
   return data;
 }
 
-#ifndef __WIN32__
+#ifndef _WIN32
 static void unmap_file(char *data, uint64 size)
 {
   if (!data) return;
@@ -1493,7 +1506,7 @@ static ubyte decompress_pairs(struct PairsData *d, uint64 idx)
   int sym, bitcnt;
 
 #ifdef DECOMP64
-  uint64 code = __builtin_bswap64(*((uint64 *)ptr));
+  uint64 code = bswap64(*((uint64 *)ptr));
   ptr += 2;
   bitcnt = 0; // number of "empty bits" in code
   for (;;) {
@@ -1506,12 +1519,14 @@ static ubyte decompress_pairs(struct PairsData *d, uint64 idx)
     bitcnt += l;
     if (bitcnt >= 32) {
       bitcnt -= 32;
-      code |= ((uint64)(__builtin_bswap32(*ptr++))) << bitcnt;
+      uint32 data = *ptr++;
+      code |= ((uint64)(bswap32(data))) << bitcnt;
     }
   }
 #else
   uint32 next = 0;
-  uint32 code = __builtin_bswap32(*ptr++);
+  uint32 data = *ptr++;
+  uint32 code = bswap32(data);
   bitcnt = 0; // number of bits in next
   for (;;) {
     int l = m;
@@ -1525,7 +1540,7 @@ static ubyte decompress_pairs(struct PairsData *d, uint64 idx)
 	code |= (next >> (32 - l));
 	l -= bitcnt;
       }
-      next = __builtin_bswap32(*ptr++);
+      next = bswap32(*ptr++);
       bitcnt = 32;
     }
     code |= (next >> (32 - l));

--- a/src/tbcore.h
+++ b/src/tbcore.h
@@ -5,7 +5,7 @@
 #ifndef TBCORE_H
 #define TBCORE_H
 
-#ifndef __WIN32__
+#ifndef _WIN32
 #include <pthread.h>
 #define SEP_CHAR ':'
 #define FD int
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef TB_HAVE_THREADS
-#ifndef __WIN32__
+#ifndef _WIN32
 #define LOCK_T pthread_mutex_t
 #define LOCK_INIT(x) pthread_mutex_init(&(x), NULL)
 #define LOCK(x) pthread_mutex_lock(&(x))
@@ -81,7 +81,12 @@ struct TBEntry {
   ubyte num;
   ubyte symmetric;
   ubyte has_pawns;
-} __attribute__((__may_alias__));
+}
+#ifdef __GNUC__
+__attribute__((__may_alias__));
+#else
+;
+#endif
 
 struct TBEntry_piece {
   char *data;

--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -70,7 +70,7 @@
 
 #ifndef TB_NO_HW_POP_COUNT
 #ifdef TB_CUSTOM_POP_COUNT
-extern unsigned popcount(uint64_t x);
+#define popcount(x) TB_CUSTOM_POP_COUNT(x)
 #else
 #include <popcntintrin.h>
 #define popcount(x)             _mm_popcnt_u64((x))
@@ -125,7 +125,7 @@ unsigned TB_LARGEST = 0;
 #define file(s)                 ((s) & 0x07)
 #define board(s)                ((uint64_t)1 << (s))
 #ifdef TB_CUSTOM_LSB
-extern unsigned lsb(uint64_t b);
+#define lsb(b) TB_CUSTOM_LSB(b)
 #else
 static inline unsigned lsb(uint64_t b)
 {

--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -29,7 +29,9 @@
 
 #include "tbprobe.h"
 
+#ifdef __GNUC__
 #include <x86intrin.h>
+#endif
 
 #define WHITE_KING              (TB_WPAWN + 5)
 #define WHITE_QUEEN             (TB_WPAWN + 4)
@@ -67,8 +69,12 @@
 #define SCORE_ILLEGAL           0x7FFF
 
 #ifndef TB_NO_HW_POP_COUNT
+#ifdef TB_CUSTOM_POP_COUNT
+extern unsigned popcount(uint64_t x);
+#else
 #include <popcntintrin.h>
 #define popcount(x)             _mm_popcnt_u64((x))
+#endif
 #else
 static inline unsigned popcount(uint64_t x)
 {
@@ -118,12 +124,16 @@ unsigned TB_LARGEST = 0;
 #define rank(s)                 ((s) >> 3)
 #define file(s)                 ((s) & 0x07)
 #define board(s)                ((uint64_t)1 << (s))
+#ifdef TB_CUSTOM_LSB
+extern unsigned lsb(uint64_t b);
+#else
 static inline unsigned lsb(uint64_t b)
 {
     size_t idx;
     __asm__("bsfq %1, %0": "=r"(idx): "rm"(b));
     return idx;
 }
+#endif
 #define square(r, f)            (8 * (r) + (f))
 
 #ifdef TB_KING_ATTACKS
@@ -684,7 +694,11 @@ static int probe_wdl_table(const struct pos *pos, int *success)
                 return 0;
             }
             // Memory barrier to ensure ptr->ready = 1 is not reordered.
+#ifdef __GNUC__
             __asm__ __volatile__ ("" ::: "memory");
+#elif defined(_MSC_VER)
+            MemoryBarrier();
+#endif
             ptr->ready = 1;
         }
         UNLOCK(TB_MUTEX);
@@ -1817,7 +1831,7 @@ extern unsigned tb_probe_wdl_impl(
         knights,
         pawns,
         0,
-        ep,
+        (uint8_t)ep,
         turn
     };
     int success;
@@ -1851,8 +1865,8 @@ extern unsigned tb_probe_root_impl(
         bishops,
         knights,
         pawns,
-        rule50,
-        ep,
+        (uint8_t)rule50,
+        (uint8_t)ep,
         turn
     };
     int dtz;


### PR DESCRIPTION
1. Allow overriding internal implementions of lsb, popcount, and bswap
   functions.
2. Use `_WIN32` not `__WIN32__` to detect Windows/MSVC
3. Don't import `<unistd.h>` if Windows
4. Misc other fixes for places that assumed GCC.
