### PR TITLE
Remove "extern" from impl function definitions

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -1790,7 +1790,7 @@ static uint16_t probe_root(const struct pos *pos, int *score,
     }
 }
 
-extern bool tb_init_impl(const char *path)
+bool tb_init_impl(const char *path)
 {
     if (sizeof(uint64_t) != 8 &&        // Paranoid check
             sizeof(uint32_t) != 4 &&
@@ -1808,7 +1808,7 @@ extern bool tb_init_impl(const char *path)
     return true;
 }
 
-extern unsigned tb_probe_wdl_impl(
+unsigned tb_probe_wdl_impl(
     uint64_t white,
     uint64_t black,
     uint64_t kings,
@@ -1841,7 +1841,7 @@ extern unsigned tb_probe_wdl_impl(
     return (unsigned)(v + 2);
 }
 
-extern unsigned tb_probe_root_impl(
+unsigned tb_probe_root_impl(
     uint64_t white,
     uint64_t black,
     uint64_t kings,


### PR DESCRIPTION
"extern" is not needed and Intel C++ does not like this (will generate link errors).
