### PR TITLE
Do not allow pawns on backrank

### DIFF
--- a/src/tbprobe.c
+++ b/src/tbprobe.c
@@ -1178,10 +1178,14 @@ static bool is_en_passant(const struct pos *pos, uint16_t move)
 }
 
 /*
- * Test if the given position is legal (can the king be captured?)
+ * Test if the given position is legal.
+ * (Pawns on backrank? Can the king be captured?)
  */
 static bool is_legal(const struct pos *pos)
 {
+    if (pos->pawns & BOARD_FILE_EDGE)
+        return false;
+
     uint64_t occ = pos->white | pos->black;
     uint64_t us = (pos->turn? pos->black: pos->white),
              them = (pos->turn? pos->white: pos->black);


### PR DESCRIPTION
Example:

```
./fathom.linux --path syzygy "1P6/4k3/8/8/8/8/4K3/8 w - - 0 1"
```

![image](https://cloud.githubusercontent.com/assets/402777/15304336/0bf3d60a-1bbd-11e6-8e9c-0af48cda6c8f.png)

Expected / after fix:

```
error: unable to probe tablebase; position invalid, illegal or not in tablebase
```

Actual output:

```
[Event ""]
[Site ""]
[Date "??"]
[Round "-"]
[White "Syzygy"]
[Black "Syzygy"]
[Result "1-0"]
[FEN "1P6/4k3/8/8/8/8/4K3/8 w - - 0 1"]
[WDL "Win"]
[DTZ "1"]
[WinningMoves "Kd1, Kd3, Ke3, b1=Q, b1=R"]
[DrawingMoves "Ke1, Kf1, Kd2, Kf2, Kf3, b1=N, b1=B"]
[LosingMoves ""]

1. b1=Q Kd6 2. Kd3 Kc5 3. Ke4 Kc4 4. Qc1+ Kb3 5. Kd3 Ka2 6. Kd4 Kb3 7. Qb1+ Ka3 8. Kc3 Ka4 9. Qb4# 1-0
```

Notice the funny move b1=Q because the bitboard wraps.
