### PR TITLE
Fix en passant in do_move()

### DIFF
--- a/src/apps/fathom.c
+++ b/src/apps/fathom.c
@@ -407,7 +407,7 @@ static void do_move(struct pos *pos, unsigned move)
             ep = from-8;
         else if (TB_GET_EP(move))
         {
-            unsigned ep_to = (pos->turn? to+8: to-8);
+            unsigned ep_to = (pos->turn? to-8: to+8);
             uint64_t ep_mask = ~board(ep_to);
             white &= ep_mask;
             black &= ep_mask;


### PR DESCRIPTION
Check out `8/8/8/8/6pP/8/8/k6K b - h3 0 1`. Last move was h4, allowing en passant on the next move.

![image](https://cloud.githubusercontent.com/assets/402777/15876939/e78e1c98-2d10-11e6-9874-af8d1d59e092.png)
1. h5 should not be a legal move, because that pawn should have been captured.

```
[Event ""]
[Site ""]
[Date "??"]
[Round "-"]
[White "Syzygy"]
[Black "Syzygy"]
[Result "1/2-1/2"]
[FEN "8/8/8/8/6pP/8/8/k6K b - h3 0 1"]
[WDL "Draw"]
[DTZ "0"]
[WinningMoves ""]
[DrawingMoves "gxh3"]
[LosingMoves "Kb1, Ka2, Kb2, g3"]

1... gxh3 2. h5 Kb1 3. h6 Ka1 4. h7 Kb1 5. h8=Q Kc1 6. Qxh3 Kb2 7. Kg1 Kb1 8. Kf1 Kc1 9. Ke1 Kc2 10. Ke2 Kb1 11. Kd1 Ka1 12. Kc1 Ka2 13. Kc2 Ka1 14. Qa3# 1-0
```

The fix is similar to https://github.com/basil00/Fathom/commit/45ae9beb1e813e3306ddcd871f7df3493aa35849#diff-98bbf44ad0a296906914322f9b11cd63L1350.
